### PR TITLE
Strip the .tl extension to look more like idiomatic dust

### DIFF
--- a/dust/build.sbt
+++ b/dust/build.sbt
@@ -4,15 +4,19 @@ sbtPlugin := true
 
 name := "play-plugins-dust"
 
-version := "1.0-SNAPSHOT"
+version := "1.4-SNAPSHOT"
 
 organization := "com.typesafe"
+
+resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 libraryDependencies <++= (scalaVersion, sbtVersion) { 
 	case (scalaVersion, sbtVersion) => Seq(
 		sbtPluginExtra("play" % "sbt-plugin" % "2.0", sbtVersion, scalaVersion)
 	)
 }
+
+libraryDependencies += "commons-io" % "commons-io" % "2.2"
 
 publishMavenStyle := false
 

--- a/dust/src/main/scala/com/typesafe/plugin/DustPlugin.scala
+++ b/dust/src/main/scala/com/typesafe/plugin/DustPlugin.scala
@@ -2,6 +2,7 @@ package com.typesafe.plugin
 
 import sbt._
 import Keys._
+import org.apache.commons.io.FilenameUtils
 
 object DustPlugin extends Plugin with DustTasks {
 
@@ -10,7 +11,7 @@ object DustPlugin extends Plugin with DustTasks {
     dustFileEnding := ".tl",
     dustAssetsGlob <<= (dustAssetsDir)(assetsDir => assetsDir ** "*.tl"),
     dustFileRegexFrom <<= (dustFileEnding)(fileEnding => fileEnding),
-    dustFileRegexTo <<= (dustFileEnding)(fileEnding => fileEnding + ".js"),
+    dustFileRegexTo <<= (dustFileEnding)(fileEnding => FilenameUtils.removeExtension(fileEnding) + ".js"),
     resourceGenerators in Compile <+= DustCompiler)
 
 }

--- a/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
+++ b/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
@@ -3,6 +3,7 @@ package com.typesafe.plugin
 import java.io.File
 import java.io.FileInputStream
 import java.io.InputStreamReader
+import org.apache.commons.io.FilenameUtils
 import org.mozilla.javascript.tools.shell.Global
 import org.mozilla.javascript.Context
 import org.mozilla.javascript.JavaScriptException
@@ -70,7 +71,7 @@ trait DustTasks extends DustKeys {
 
         val generated = (files x relativeTo(assetsDir)).flatMap {
           case (sourceFile, name) => {
-            val msg = compile(sourceFile.getPath.replace(assetsDir.getPath + "/", ""), IO.read(sourceFile)).left.map {
+            val msg = compile(FilenameUtils.removeExtension(sourceFile.getPath.replace(assetsDir.getPath + "/", "")), IO.read(sourceFile)).left.map {
               case (msg, line, column) => throw AssetCompilationException(Some(sourceFile),
                 msg,
                 line,


### PR DESCRIPTION
As described in issue #1, a template `foo.tl` would be compiled to `foo.tl.js` and register itself as `foo.tl`. This meant that you had to add ".tl" all over the code, which is not DRY and not idiomatic dust. This patch strips the .tl file extension so the compiled template ends up as `foo.js` and registers itself as `foo`.
