### PR TITLE
fix custom config.file reference under windows

### DIFF
--- a/sbtgoodies/src/main/scala/com/typesafe/plugin/sbtGoodiesTasks.scala
+++ b/sbtgoodies/src/main/scala/com/typesafe/plugin/sbtGoodiesTasks.scala
@@ -35,7 +35,7 @@ trait SbtGoodiesTasks extends SbtGoodiesKeys {
              |setlocal
              |set p=%~dp0
              |set p=%p:\=/%
-             |java %* -cp "%p%lib/*" """ + config.map(_ => "-Dconfig.file=%p%application.conf ").getOrElse("") + """play.core.server.NettyServer "%p%"
+             |java %* -cp "%p%lib/*" """ + config.map(fn => "-Dconfig.file=\"%p%" + fn + "\" ").getOrElse("") + """play.core.server.NettyServer "%p%"
              |""".stripMargin)
       }
       IO.delete(zip)


### PR DESCRIPTION
The start.bat generated by sbtgoodies always references application.conf, which doesn't match the custom config file name change to the linux start script in Play20 here:
https://github.com/playframework/Play20/commit/db6e176ea0284679904e02304d0b94dc971d9bc9
