### PR TITLE
Make dist-unzip depend on dist

### DIFF
--- a/sbtgoodies/src/main/scala/com/typesafe/plugin/SbtGoodiesPlugin.scala
+++ b/sbtgoodies/src/main/scala/com/typesafe/plugin/SbtGoodiesPlugin.scala
@@ -6,6 +6,7 @@ import Keys._
 object SbtGoodiesPlugin extends Plugin with SbtGoodiesTasks {
 
   override def settings: Seq[Setting[_]] = super.settings ++ Seq(
-     distUnzip <<= distUnzipTask 
+     distUnzip <<= distUnzipTask,
+     distUnzip <<= distUnzip.dependsOn(PlayProject.dist)
   )
 }


### PR DESCRIPTION
It's annoying to have to run "dist" before "dist-unzip" everytime.  It's impossible to run "dist-unzip" without "dist", so it should be dependent upon it.

https://github.com/typesafehub/play-plugins/issues/9
