### PR TITLE
The dust plugin example uses the wrong suffix for template

### DIFF
--- a/dust/README.md
+++ b/dust/README.md
@@ -27,14 +27,14 @@ to your plugin.sbt
 * Put your dust template .tl files under the ```app/assets``` directory
 
 * Reference the generated .js in a  ```<script>``` tag:
-```<script src="@routes.Assets.at("example.tl.js")"></script>```
+```<script src="@routes.Assets.at("example.js")"></script>```
 
 * Render the template when you receive the json 
 ```
   $(function() {
 	$.get('@routes.Application.data', function(data) {
 	  console.log('data = ' + JSON.stringify(data));
-	  dust.render('example.tl', data, function(err, out) {
+	  dust.render('example', data, function(err, out) {
 	    $('#dust_pan').html(err ? err : out);
 	  });
 	});

--- a/dust/sample/app/views/index.scala.html
+++ b/dust/sample/app/views/index.scala.html
@@ -8,12 +8,12 @@
         <title>Test</title>
         <script src="@routes.Assets.at("javascripts/jquery-1.7.1.min.js")"></script>
         <script src="@routes.Assets.at("javascripts/dust-core-0.6.0.min.js")"></script>
-        <script src="@routes.Assets.at("example.tl.js")"></script>
+        <script src="@routes.Assets.at("example.js")"></script>
         <script>
   $(function() {
 	$.get('@routes.Application.data', function(data) {
 	  console.log('data = ' + JSON.stringify(data));
-	  dust.render('example.tl', data, function(err, out) {
+	  dust.render('example', data, function(err, out) {
 	    $('#dust_pan').html(err ? err : out);
 	  });
 	});


### PR DESCRIPTION
[title was The dust plugin doesn't compile assets]

I've tried using the dust plugin in my own project and running the sample (git head on play 2.0.2) but in both cases the .tl assets under app/assets don't get compiled. Running the sample app then shows a blank an empty page with an error on the console:

```
GET http://localhost:8002/assets/example.tl.js 404 (Not Found)
```
