### PR TITLE
Correctly identify Windows hosts when os.name property starts with "win"

### DIFF
--- a/sbtgoodies/src/main/scala/com/typesafe/plugin/sbtGoodiesTasks.scala
+++ b/sbtgoodies/src/main/scala/com/typesafe/plugin/sbtGoodiesTasks.scala
@@ -22,7 +22,7 @@ trait SbtGoodiesTasks extends SbtGoodiesKeys {
       IO.unzip(zip, distDir)
       val os = System.getProperty("os.name").toLowerCase()
 
-      if (os.indexOf("win") <= 0) {
+      if (os.indexOf("win") < 0) {
         //nix
         val libc = Native.loadLibrary("c", classOf[CLibrary]).asInstanceOf[CLibrary]
         libc.chmod(unzippedDir.getAbsolutePath+"/start", 0755)


### PR DESCRIPTION
os.indexOf("win") <= 0 will return true if "win" is not found **or** the string starts with
"win". This will improperly treat platforms which start with "win", e.g. "Windows 7" as if
they are *nix. Testing os.indexOf("win") < 0 will return true only if "win" is not found.

When a Windows host is treated as if it is *nix, the request to load the "c" native library fails,
resulting in:

```
[error] {file:/C:/<blah>/}<blah>
<blah>/*:dist-unzip: java.lang.UnsatisfiedLinkError: Unable to load library 'c':
 The specified module could not be found.
```

This appears to be the same problem encountered by this user: https://groups.google.com/d/msg/play-framework/i86yduDeMPU/24A6E8Kk5m0J
