### PR TITLE
Fix for Issue 14: Allow sbtgoodies plugin to be applied if project has non-Play subproject

### DIFF
--- a/sbtgoodies/src/main/scala/com/typesafe/plugin/SbtGoodiesPlugin.scala
+++ b/sbtgoodies/src/main/scala/com/typesafe/plugin/SbtGoodiesPlugin.scala
@@ -5,7 +5,7 @@ import Keys._
 
 object SbtGoodiesPlugin extends Plugin with SbtGoodiesTasks {
 
-  override def settings: Seq[Setting[_]] = super.settings ++ Seq(
+  val distUnzipSettings: Seq[Setting[_]] = Seq(
      distUnzip <<= distUnzipTask,
      distUnzip <<= distUnzip.dependsOn(PlayProject.dist)
   )


### PR DESCRIPTION
According to the [SBT Plugins Best Practices](https://github.com/harrah/xsbt/wiki/Plugins-Best-Practices):

```
Overriding val settings should only be done by plugins intending to provide commands. Regular plugins defining tasks and settings should provide a sequence named after the plugin.
```
