### PR TITLE
Update sbt version to 0.12

### DIFF
--- a/dust/project/build.properties
+++ b/dust/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/dust/sample/project/build.properties
+++ b/dust/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/guice/project/build.properties
+++ b/guice/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/guice/sample/project/build.properties
+++ b/guice/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/inject/project/build.properties
+++ b/inject/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/inject/sample/project/build.properties
+++ b/inject/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/inject/sample_without_static_field/project/build.properties
+++ b/inject/sample_without_static_field/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/mailer/project/build.properties
+++ b/mailer/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/mailer/sample/project/build.properties
+++ b/mailer/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/redis/project/build.properties
+++ b/redis/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/redis/sample/project/build.properties
+++ b/redis/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/sbtgoodies/project/build.properties
+++ b/sbtgoodies/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/sbtgoodies/sample/project/build.properties
+++ b/sbtgoodies/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/sbtlogger/project/build.properties
+++ b/sbtlogger/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0

--- a/util/project/build.properties
+++ b/util/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.0


### PR DESCRIPTION
SBT 0.12 is out:
https://groups.google.com/d/topic/simple-build-tool/XDTrQL-PcYo/discussion

If you rebuild for 0.12 can you please take a look at committing this bug fix?
https://github.com/typesafehub/play-plugins/pull/24

Thanks!
