### PR TITLE
Fix doc and sample #27

### DIFF
--- a/dust/README.md
+++ b/dust/README.md
@@ -27,7 +27,7 @@ to your plugin.sbt
 * Put your dust template .tl files under the ```app/assets``` directory
 
 * Reference the generated .js in a  ```<script>``` tag:
-```<script src="@routes.Assets.at("example.tl.js")"></script>```
+```<script src="@routes.Assets.at("example.js")"></script>```
 
 * Render the template when you receive the json 
 ```

--- a/dust/sample/app/views/index.scala.html
+++ b/dust/sample/app/views/index.scala.html
@@ -8,7 +8,7 @@
         <title>Test</title>
         <script src="@routes.Assets.at("javascripts/jquery-1.7.1.min.js")"></script>
         <script src="@routes.Assets.at("javascripts/dust-core-0.6.0.min.js")"></script>
-        <script src="@routes.Assets.at("example.tl.js")"></script>
+        <script src="@routes.Assets.at("example.js")"></script>
         <script>
   $(function() {
 	$.get('@routes.Application.data', function(data) {


### PR DESCRIPTION
From: https://github.com/typesafehub/play-plugins/issues/27

Ok, so I took a little time to read the code, and actually the answer is pretty simple, in `DustPlugin.scala` you remove the `.tl` extension. So I updated the code, by fixing the doc and sample.
