### PR TITLE
Mark the sbt dependency as provided

### DIFF
--- a/sbtgoodies/build.sbt
+++ b/sbtgoodies/build.sbt
@@ -4,11 +4,11 @@ sbtPlugin := true
 
 name := "play-plugins-sbtgoodies"
 
-version := "0.2"
+version := "0.3"
 
 organization := "com.typesafe"
 
-addSbtPlugin("play" % "sbt-plugin" % "2.1-08072012")
+addSbtPlugin("play" % "sbt-plugin" % "2.1-08072012" % "provided")
 
 libraryDependencies += "com.sun.jna" % "jna" % "3.0.9"
 


### PR DESCRIPTION
Mark the sbt dependency as provided so the version specified here does not override the version supplied by the user

I mentioned this problem on the mailing list:
https://groups.google.com/forum/?fromgroups#!topic/play-framework/J1NUUsdkCTI%5B1-25%5D

I would love to get this plugin republished with the fix!  I'm stuck using a version of Play from a few days ago with the sbt test forking issue until this is fixed, which is pretty disruptive to my work.

Thanks!
