### PR TITLE
Fix error reporting in dust plugin so line and column numbers show up

### DIFF
--- a/dust/build.sbt
+++ b/dust/build.sbt
@@ -4,7 +4,7 @@ sbtPlugin := true
 
 name := "play-plugins-dust"
 
-version := "1.4"
+version := "1.4.1"
 
 organization := "com.typesafe"
 

--- a/dust/sample/app/views/index.scala.html
+++ b/dust/sample/app/views/index.scala.html
@@ -8,12 +8,12 @@
         <title>Test</title>
         <script src="@routes.Assets.at("javascripts/jquery-1.7.1.min.js")"></script>
         <script src="@routes.Assets.at("javascripts/dust-core-0.6.0.min.js")"></script>
-        <script src="@routes.Assets.at("example.tl.js")"></script>
+        <script src="@routes.Assets.at("example.js")"></script>
         <script>
   $(function() {
 	$.get('@routes.Application.data', function(data) {
 	  console.log('data = ' + JSON.stringify(data));
-	  dust.render('example.tl', data, function(err, out) {
+	  dust.render('example', data, function(err, out) {
 	    $('#dust_pan').html(err ? err : out);
 	  });
 	});

--- a/dust/sample/project/plugins.sbt
+++ b/dust/sample/project/plugins.sbt
@@ -8,6 +8,6 @@ resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/release
 resolvers += Resolver.url("Typesafe Ivy Snapshots Repository", url("http://repo.typesafe.com/typesafe/ivy-snapshots/"))(Resolver.ivyStylePatterns)
 
 // The Dust plugin
-addSbtPlugin("com.typesafe" % "play-plugins-dust" % "1.4")
+addSbtPlugin("com.typesafe" % "play-plugins-dust" % "1.4.1")
 
 // Use the Play sbt plugin for Play projects


### PR DESCRIPTION
Pull request for issue #35.
1. Pull the proper line and column number info when there is a dust compile failure. This avoids the `NumberFormatException` and brings back clean error reporting.
2. Bump the (minor) version number
3. Fix bug in the sample app where it was still including the `.tl` extension in the URL and `dust.render` call. This is a bug from my previous pull request, sorry :)
