### PR TITLE
Fix critical windows bug in the Dust plugin

### DIFF
--- a/dust/build.sbt
+++ b/dust/build.sbt
@@ -18,6 +18,8 @@ libraryDependencies <++= (scalaVersion) {
 
 libraryDependencies += "commons-io" % "commons-io" % "2.2"
 
+libraryDependencies += "org.specs2" %% "specs2" % "1.12.3" % "test"
+
 publishMavenStyle := false
 
 publishTo <<= (version) { version: String =>

--- a/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
+++ b/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
@@ -58,8 +58,10 @@ trait DustTasks extends DustKeys {
   }
 
   protected def templateName(sourceFile: String, assetsDir: String): String = {
+    val sourceFileWithForwardSlashes = FilenameUtils.separatorsToUnix(sourceFile)
+    val assetsDirWithForwardSlashes  = FilenameUtils.separatorsToUnix(assetsDir)
     FilenameUtils.removeExtension(
-      sourceFile.replace(assetsDir + "/", "")
+      sourceFileWithForwardSlashes.replace(assetsDirWithForwardSlashes + "/", "")
     )
   }
 

--- a/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
+++ b/dust/src/main/scala/com/typesafe/plugin/DustTasks.scala
@@ -57,6 +57,12 @@ trait DustTasks extends DustKeys {
     }
   }
 
+  protected def templateName(sourceFile: String, assetsDir: String): String = {
+    FilenameUtils.removeExtension(
+      sourceFile.replace(assetsDir + "/", "")
+    )
+  }
+
   import Keys._
 
   lazy val DustCompiler = (sourceDirectory in Compile, resourceManaged in Compile, cacheDirectory, dustFileRegexFrom, dustFileRegexTo, dustAssetsDir, dustAssetsGlob) map {
@@ -76,7 +82,7 @@ trait DustTasks extends DustKeys {
 
         val generated = (files x relativeTo(assetsDir)).flatMap {
           case (sourceFile, name) => {
-            val msg = compile(FilenameUtils.removeExtension(sourceFile.getPath.replace(assetsDir.getPath + "/", "")), IO.read(sourceFile)).left.map {
+            val msg = compile(templateName(sourceFile.getPath, assetsDir.getPath), IO.read(sourceFile)).left.map {
               case (msg, line, column) => throw AssetCompilationException(Some(sourceFile),
                 msg,
                 line,
@@ -98,5 +104,4 @@ trait DustTasks extends DustKeys {
         previousGeneratedFiles.toSeq
       }
   }
-
 }

--- a/dust/src/test/scala/com/typesafe/plugin/DustTasksTest.scala
+++ b/dust/src/test/scala/com/typesafe/plugin/DustTasksTest.scala
@@ -1,0 +1,17 @@
+import org.specs2.mutable._
+import com.typesafe.plugin._
+
+class HelloWorldSpec extends Specification with DustTasks {
+  "The Dust compiler" should {
+    "resolve template names correctly on Unix" in {
+      val file = "/var/projects/sample/app/assets/templates/foo.tl"
+      val assetsDir = "/var/projects/sample/app/assets"
+      templateName(file, assetsDir) must be_==("templates/foo")
+    }
+    "resolve template names correctly on Windows" in {
+      val file = "C:\\projects\\sample\\app\\assets\\templates\\foo.tl"
+      val assetsDir = "C:\\projects\\sample\\app\\assets"
+      templateName(file, assetsDir) must be_==("templates/foo")
+    }
+  }
+}


### PR DESCRIPTION
The plugin doesn't work on Windows because of Windows' backslashes.

I submitted a few unit tests and a fix. If you don't want the unit tests, you can cherry-pick the first and last commit.

More explanations in the commit messages.
