### PR TITLE
Add support for StatsD delta guage values

### DIFF
--- a/statsd/documentation/manual/home.textile
+++ b/statsd/documentation/manual/home.textile
@@ -38,6 +38,8 @@ Statsd.time("my.operation.i.dont.want.to.time.myself") {
   // do some stuff...
 } // This will get timed automatically.
 Statsd.gauge("my.value", 42)  // Record 42 for my.value
+Statsd.gauge("my.value", 10, true)  // Increment my.value by 10
+Statsd.gauge("my.value", -10, true)  // Decrement my.value by 10
 
 p(note). Any errors will be logged, but will not cause the app to fail.
 
@@ -59,6 +61,8 @@ String result = Statsd.time("my.operation.i.dont.want.to.time.myself", new F.Fun
     return "some result";
   }}); // This will get timed automatically.
 Statsd.gauge("my.value", 42L)  // Record 42 for my.value
+Statsd.gauge("my.value", 10L, true)  // Increment my.value by 10
+Statsd.gauge("my.value", -10L, true)  // Decrement my.value by 10
 
 p(note). Any errors will be logged, but will not cause the app to fail.
 

--- a/statsd/src/main/java/play/modules/statsd/Statsd.java
+++ b/statsd/src/main/java/play/modules/statsd/Statsd.java
@@ -111,6 +111,16 @@ public class Statsd {
     public static void gauge(String key, long value) {
         client().gauge(key, value);
     }
+    
+    /**
+     * Record the given value.
+     *
+     * @param key The stat key to update.
+     * @param value The value to record for the stat.
+     */
+    public static void gauge(String key, long value, boolean delta) {
+        client().gauge(key, value, delta);
+    }    
 
     private static StatsdClient client() {
         return Statsd$.MODULE$;

--- a/statsd/src/test/java/play/modules/statsd/StatsdTest.java
+++ b/statsd/src/test/java/play/modules/statsd/StatsdTest.java
@@ -46,6 +46,14 @@ public class StatsdTest {
         Statsd.gauge("test", 42);
         assertThat(receive(), equalTo("statsd.test:42|g"));
     }
+    
+    @Test
+    public void gaugeWithDeltaShouldSendGaugeMessage() throws Exception {
+        Statsd.gauge("test", 10, true);
+        assertThat(receive(), equalTo("statsd.test:+10|g"));
+        Statsd.gauge("test", -10, true);
+        assertThat(receive(), equalTo("statsd.test:-10|g"));
+    }
 
     @Test
     public void incrementShouldSendIncrementByOneMessage() throws Exception {

--- a/statsd/src/test/scala/play/modules/statsd/api/StatsdSpec.scala
+++ b/statsd/src/test/scala/play/modules/statsd/api/StatsdSpec.scala
@@ -14,6 +14,14 @@ class StatsdSpec extends Specification {
         receive() mustEqual "statsd.test:42|g"
       }
     }
+    "send delta gauge value" in new Setup {
+      running(fakeApp) {
+        Statsd.gauge("test", 10, true)
+        receive() mustEqual "statsd.test:+10|g"
+        Statsd.gauge("test", -10, true)
+        receive() mustEqual "statsd.test:-10|g"
+      }
+    }    
     "send increment by one message" in new Setup {
       running(fakeApp) {
         Statsd.increment("test")


### PR DESCRIPTION
Statsd has supported incrementing guage values since 0.6.0 using +/-
values.

Added support for this by adding a new guage method which accepts a
delta boolean flag similar to the python statsd api.

Needed to add a statFor method which accepts a string value to accomplish this.
