### PR TITLE
Removing warn level redis cache logging

### DIFF
--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -81,7 +81,7 @@ class RedisPlugin(app: Application) extends CachePlugin {
           throw new IOException("could not serialize: "+ value.toString)
        }
        val redisV = prefix + "-" + new String( Base64Coder.encode( baos.toByteArray() ) )  
-       Logger.warn(redisV)
+       Logger.debug(redisV)
        sedisPool.withJedisClient { client =>
           client.set(key,redisV)
           if (expiration != 0) client.expire(key,expiration)


### PR DESCRIPTION
Integrated the redis caching and saw a ton of warn level debug, changing the object logging to debug. 
