### PR TITLE
Fix logging in Redis cache, allow URI-based Redis configuration, expose Redis connection pool configuration

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -4,7 +4,7 @@ This plugin provides support for [Redis](http://redis.io/) using the best Java d
 
 # Features
 
-*  Provides a Redis-based Cache API (supported types: String, Int, Long, Boolean and Serializable) ie.
+###  Provides a Redis-based Cache API (supported types: String, Int, Long, Boolean and Serializable) ie.
 
 ```java
 //java
@@ -18,9 +18,28 @@ and
 val o = play.api.cache.Cache.getAs[String]("mykey")
 ```
 
-* configurable ( variables: ```redis.host```, ```redis.port```, ```redis.timeout```, ```redis.password```, defaults are ```localhost```, ```6379```, ```2000```, ```nul``` )
+#### Configurable
 
-* Allows direct access to Jedis and Sedis: 
+* Point to your Redis server using configuration settings  ```redis.host```, ```redis.port``` and ```redis.password``` (defaults: ```localhost```, ```6379``` and ```null``` )
+* Alternatively, specify a URI-based configuration using ```redis.uri``` (for example: ```redis.uri="redis://user:password@localhost:6379"```).
+* Set the timeout in milliseconds using ```redis.timeout``` (default is 2000).
+* Configure any aspect of the connection pool. See [the documentation for commons-pool ```GenericObjectPool```](http://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool/impl/GenericObjectPool.html), the underlying pool implementation, for more information on each setting.
+    * redis.pool.maxIdle
+    * redis.pool.minIdle
+    * redis.pool.maxActive
+    * redis.pool.maxWait
+    * redis.pool.testOnBorrow
+    * redis.pool.testOnReturn
+    * redis.pool.testWhileIdle
+    * redis.pool.timeBetweenEvictionRunsMillis
+    * redis.pool.numTestsPerEvictionRun
+    * redis.pool.minEvictableIdleTimeMillis
+    * redis.pool.softMinEvictableIdleTimeMillis
+    * redis.pool.lifo
+    * redis.pool.whenExhaustedAction (valid options: "fail", "block" (default), "grow")
+
+
+#### Allows direct access to Jedis and Sedis: 
 
 ```java
 //java

--- a/redis/sample/app/controllers/Application.java
+++ b/redis/sample/app/controllers/Application.java
@@ -14,7 +14,7 @@ public class Application extends Controller {
   public static Result index() {
     JedisPool p = Play.application().plugin(RedisPlugin.class).jedisPool();
     Jedis j = p.getResource();
-    String r = j.get("foo") + " - foo2:" + j.get("foo2") ;
+    String r = j.get("foo") + " - foo2:" + j.get("foo2");
     p.returnResource(j);
     return ok(index.render("foo3:"+ Cache.get("foo3")+" foo2:"+Cache.get("foo2").toString() +" - redis:" + r ));
   }

--- a/redis/sample/conf/application.conf
+++ b/redis/sample/conf/application.conf
@@ -54,5 +54,5 @@ logger.root=ERROR
 logger.play=INFO
 
 # Logger provided to your application:
-logger.application=DEBUG
+logger.application=TRACE
 

--- a/redis/sample/project/Build.scala
+++ b/redis/sample/project/Build.scala
@@ -8,7 +8,7 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0-SNAPSHOT"
 
     val appDependencies = Seq(
-       "com.typesafe" %% "play-plugins-redis" % "2.0.4"
+       "com.typesafe" %% "play-plugins-redis" % "2.1-1-RC2"
       
     )
 

--- a/redis/sample/project/build.properties
+++ b/redis/sample/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.11.3
+sbt.version=0.12.2

--- a/redis/sample/project/plugins.sbt
+++ b/redis/sample/project/plugins.sbt
@@ -5,4 +5,4 @@ logLevel := Level.Warn
 resolvers += "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
 
 // Use the Play sbt plugin for Play projects
-addSbtPlugin("play" % "sbt-plugin" % "2.0.4")
+addSbtPlugin("play" % "sbt-plugin" % "2.1.1")

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -6,7 +6,10 @@ import redis.clients.jedis._
 import play.api.cache._
 import java.util._
 import java.io._
+import java.net.URI
 import biz.source_code.base64Coder._
+import org.apache.commons.lang3.builder._
+import org.apache.commons.pool.impl.GenericObjectPool
 
 /**
  * provides a redis client and a CachePlugin implementation
@@ -16,21 +19,62 @@ import biz.source_code.base64Coder._
  */
 class RedisPlugin(app: Application) extends CachePlugin {
 
- 
- private lazy val host = app.configuration.getString("redis.host").getOrElse("localhost")
- private lazy val port = app.configuration.getInt("redis.port").getOrElse(6379)
- private lazy val timeout = app.configuration.getInt("redis.timeout").getOrElse(2000)
- private lazy val password = app.configuration.getString("redis.password").getOrElse(null)
+ private lazy val redisUri = app.configuration.getString("redis.uri").map { new URI(_) }
+
+ private lazy val host = app.configuration.getString("redis.host")
+                         .orElse(redisUri.map{_.getHost()})
+                         .getOrElse("localhost")
+
+ private lazy val port = app.configuration.getInt("redis.port")
+                         .orElse(redisUri.map{_.getPort()}.filter{_ != -1})
+                         .getOrElse(6379)
+
+ private lazy val password = app.configuration.getString("redis.password")
+                            .orElse(redisUri.map{ _.getUserInfo() }.filter{_ != null}.filter{ _ contains ":" }.map{_.split(":", 2)(1)})
+                            .getOrElse(null)
+
+ private lazy val timeout = app.configuration.getInt("redis.timeout")
+                            .getOrElse(2000)
+
 
  /**
   * provides access to the underlying jedis Pool
   */
- lazy val jedisPool = new JedisPool(new JedisPoolConfig(), host, port, timeout, password)
+ lazy val jedisPool = {
+   val poolConfig = createPoolConfig(app)
+   Logger.info(s"Redis Plugin enabled. Connecting to Redis on ${host}:${port} with timeout ${timeout}.")
+   Logger.info("Redis Plugin pool configuration: " + new ReflectionToStringBuilder(poolConfig).toString())
+   new JedisPool(poolConfig, host, port, timeout, password)
+ }
 
   /**
   * provides access to the sedis Pool
-  */           
+  */
  lazy val sedisPool = new Pool(jedisPool)
+
+ private def createPoolConfig(app: Application) : JedisPoolConfig = {
+   val poolConfig : JedisPoolConfig = new JedisPoolConfig()
+   app.configuration.getInt("redis.pool.maxIdle").map { poolConfig.maxIdle = _ }
+   app.configuration.getInt("redis.pool.minIdle").map { poolConfig.minIdle = _ }
+   app.configuration.getInt("redis.pool.maxActive").map { poolConfig.maxActive = _ }
+   app.configuration.getInt("redis.pool.maxWait").map { poolConfig.maxWait = _ }
+   app.configuration.getBoolean("redis.pool.testOnBorrow").map { poolConfig.testOnBorrow = _ }
+   app.configuration.getBoolean("redis.pool.testOnReturn").map { poolConfig.testOnReturn = _ }
+   app.configuration.getBoolean("redis.pool.testWhileIdle").map { poolConfig.testWhileIdle = _ }
+   app.configuration.getLong("redis.pool.timeBetweenEvictionRunsMillis").map { poolConfig.timeBetweenEvictionRunsMillis = _ }
+   app.configuration.getInt("redis.pool.numTestsPerEvictionRun").map { poolConfig.numTestsPerEvictionRun = _ }
+   app.configuration.getLong("redis.pool.minEvictableIdleTimeMillis").map { poolConfig.minEvictableIdleTimeMillis = _ }
+   app.configuration.getLong("redis.pool.softMinEvictableIdleTimeMillis").map { poolConfig.softMinEvictableIdleTimeMillis = _ }
+   app.configuration.getBoolean("redis.pool.lifo").map { poolConfig.lifo = _ }
+    app.configuration.getString("redis.pool.whenExhaustedAction").map { setting =>
+      poolConfig.whenExhaustedAction = setting match {
+        case "fail"  | "0" => GenericObjectPool.WHEN_EXHAUSTED_FAIL
+        case "block" | "1" => GenericObjectPool.WHEN_EXHAUSTED_BLOCK
+        case "grow"  | "2" => GenericObjectPool.WHEN_EXHAUSTED_FAIL
+      }
+    }
+   poolConfig
+ }
 
  override def onStart() {
     sedisPool
@@ -47,14 +91,14 @@ class RedisPlugin(app: Application) extends CachePlugin {
  /**
   * cacheAPI implementation
   * can serialize, deserialize to/from redis
-  * value needs be Serializable (a few primitive types are also supported: String, Int, Long, Boolean) 
+  * value needs be Serializable (a few primitive types are also supported: String, Int, Long, Boolean)
   */
  lazy val api = new CacheAPI {
 
     def set(key: String, value: Any, expiration: Int) {
      var oos: ObjectOutputStream = null
      var dos: DataOutputStream = null
-     try { 
+     try {
        val baos = new ByteArrayOutputStream()
        var prefix = "oos"
        if (value.getClass.isInstanceOf[Serializable]) {
@@ -75,13 +119,14 @@ class RedisPlugin(app: Application) extends CachePlugin {
           prefix = "long"
        } else if (value.getClass.isInstanceOf[Boolean]) {
           dos = new DataOutputStream(baos)
-          dos.writeBoolean(value.asInstanceOf[Boolean]) 
-          prefix = "boolean"   
+          dos.writeBoolean(value.asInstanceOf[Boolean])
+          prefix = "boolean"
        } else {
           throw new IOException("could not serialize: "+ value.toString)
        }
-       val redisV = prefix + "-" + new String( Base64Coder.encode( baos.toByteArray() ) )  
-       Logger.warn(redisV)
+       val redisV = prefix + "-" + new String( Base64Coder.encode( baos.toByteArray() ) )
+       Logger.trace(s"Setting key ${key} to ${redisV}")
+       
        sedisPool.withJedisClient { client =>
           client.set(key,redisV)
           if (expiration != 0) client.expire(key,expiration)
@@ -92,43 +137,48 @@ class RedisPlugin(app: Application) extends CachePlugin {
        if (oos != null) oos.close()
        if (dos != null) dos.close()
      }
-    
+
     }
     def remove(key: String): Unit =  sedisPool.withJedisClient { client => client.del(key) }
 
     def get(key: String): Option[Any] = {
+      Logger.trace(s"Reading key ${key}")
+      
       var ois: ObjectInputStream = null
       var dis: DataInputStream = null
       try {
-        val data: Seq[String] =  sedisPool.withJedisClient { client =>
-            client.get(key)
-        }.split("-")
-        val b = Base64Coder.decode(data.last)
-        data.head match {
-          case "oos" => 
-              ois = new ObjectInputStream(new ByteArrayInputStream(b))
-              val r  = ois.readObject()
-              Some(r)
-          case "string" => 
-              dis = new DataInputStream(new ByteArrayInputStream(b))
-              val r  = dis.readUTF()
-              Some(r)
-          case "int" =>  
-              dis = new DataInputStream(new ByteArrayInputStream(b))
-               val r  = dis.readInt
-              Some(r)
-          case "long" => 
-              dis = new DataInputStream(new ByteArrayInputStream(b))
-              val r  = dis.readLong
-              Some(r)
-          case "boolean" =>   
-              dis = new DataInputStream(new ByteArrayInputStream(b))
-              val r  = dis.readBoolean
-              Some(r)
-          case _ => throw new IOException("can not recognize value")
+        val rawData = sedisPool.withJedisClient { client => client.get(key) }
+        rawData match {
+            case null =>
+                None
+            case _ =>
+                val data: Seq[String] =  rawData.split("-")
+                val b = Base64Coder.decode(data.last)
+                data.head match {
+                  case "oos" =>
+                      ois = new ObjectInputStream(new ByteArrayInputStream(b))
+                      val r  = ois.readObject()
+                      Some(r)
+                  case "string" =>
+                      dis = new DataInputStream(new ByteArrayInputStream(b))
+                      val r  = dis.readUTF()
+                      Some(r)
+                  case "int" =>
+                      dis = new DataInputStream(new ByteArrayInputStream(b))
+                       val r  = dis.readInt
+                      Some(r)
+                  case "long" =>
+                      dis = new DataInputStream(new ByteArrayInputStream(b))
+                      val r  = dis.readLong
+                      Some(r)
+                  case "boolean" =>
+                      dis = new DataInputStream(new ByteArrayInputStream(b))
+                      val r  = dis.readBoolean
+                      Some(r)
+                  case _ => throw new IOException("can not recognize value")
+                }
         }
-        
-      } catch {case ex: Exception => 
+      } catch {case ex: Exception =>
         Logger.warn("could not deserialize key:"+ key+ " ex:"+ex.toString)
         ex.printStackTrace()
         None


### PR DESCRIPTION
Current implementation logs a stacktrace like the one below when attempting to retrieve a key with no cached value (instead of cleanly returning None). Current implementation also logs the key at warn level on every Cache set.

```
[warn] application - could not deserialize key:nope ex:java.lang.NullPointerException
java.lang.NullPointerException
        at com.typesafe.plugin.RedisPlugin$$anon$1.get(RedisPlugin.scala:105)
        at play.api.cache.Cache$.get(Cache.scala:65)
        at play.api.cache.Cache.get(Cache.scala)
        at play.cache.Cache.get(Cache.java:16)
        at controllers.Application$2.get(Application.java:44)
        at controllers.Application$2.get(Application.java:39)
        at com.atlassian.connect.play.java.controllers.AcController.index(AcController.java:29)
        at controllers.Application.index(Application.java:19)
        at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:73)
        at Routes$$anonfun$routes$1$$anonfun$applyOrElse$1$$anonfun$apply$1.apply(routes_routing.scala:73)
        at play.core.Router$HandlerInvoker$$anon$6$$anon$2.invocation(Router.scala:164)
        at play.core.Router$Routes$$anon$1.invocation(Router.scala:345)
        at play.core.j.JavaAction$$anon$1.call(JavaAction.scala:31)
        at play.core.j.JavaAction$$anon$2.apply(JavaAction.scala:74)
        at play.core.j.JavaAction$$anon$2.apply(JavaAction.scala:73)
        at play.libs.F$Promise$PromiseActor.onReceive(F.java:420)
        at akka.actor.UntypedActor$$anonfun$receive$1.applyOrElse(UntypedActor.scala:159)
        at akka.actor.ActorCell.receiveMessage(ActorCell.scala:425)
        at akka.actor.ActorCell.invoke(ActorCell.scala:386)
        at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:230)
        at akka.dispatch.Mailbox.run(Mailbox.scala:212)
        at akka.dispatch.ForkJoinExecutorConfigurator$MailboxExecutionTask.exec(AbstractDispatcher.scala:502)
        at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:262)
        at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:975)
        at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1478)
        at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:104)
```

Also add support for URI-based connection configuration (useful for services like [RedisCloud on Heroku](https://devcenter.heroku.com/articles/rediscloud#using-redis-from-java)) and expose the connection pool configuration.
