### PR TITLE
Rename addRecipient and alike to setRecipient; fixes #56

### DIFF
--- a/mailer/README.md
+++ b/mailer/README.md
@@ -8,6 +8,10 @@ play 2.0.x:
 
 * add ```"com.typesafe" %% "play-plugins-mailer" % "2.0.4"``` to your dependencies (```project/Build.scala```)
 
+play 2.1.x:
+
+* add ```"com.typesafe" %% "play-plugins-mailer" % "2.1-RC2"``` to your dependencies (```project/Build.scala```)
+
 
 and then
 * add ```1500:com.typesafe.plugin.CommonsMailerPlugin``` to your ```conf/play.plugins```
@@ -30,8 +34,8 @@ smtp.password (optional)
 import com.typesafe.plugin.*;
 MailerAPI mail = play.Play.application().plugin(MailerPlugin.class).email();
 mail.setSubject("mailer");
-mail.addRecipient("Peter Hausel Junior <noreply@email.com>","example@foo.com");
-mail.addFrom("Peter Hausel <noreply@email.com>");
+mail.setRecipient("Peter Hausel Junior <noreply@email.com>","example@foo.com");
+mail.setFrom("Peter Hausel <noreply@email.com>");
 //sends html
 mail.sendHtml("<html>html</html>" );
 //sends text/text
@@ -46,8 +50,10 @@ mail.send( "text", "<html>html</html>");
 import com.typesafe.plugin._
 val mail = use[MailerPlugin].email
 mail.setSubject("mailer")
-mail.addRecipient("Peter Hausel Junior <noreply@email.com>","example@foo.com")
-mail.addFrom("Peter Hausel <noreply@email.com>")
+mail.setRecipient("Peter Hausel Junior <noreply@email.com>","example@foo.com")
+//or use a list
+mail.setBcc(List("Dummy <example@example.org>", "Dummy2 <example@example.org>"):_*)
+mail.setFrom("Peter Hausel <noreply@email.com>")
 //sends html
 mail.sendHtml("<html>html</html>" )
 //sends text/text

--- a/mailer/sample/app/controllers/Application.java
+++ b/mailer/sample/app/controllers/Application.java
@@ -12,8 +12,8 @@ public class Application extends Controller {
   public static Result index() {
     MailerAPI mail = play.Play.application().plugin(MailerPlugin.class).email();
     mail.setSubject("simplest mailer test");
-    mail.addRecipient("some display name <sometoadd@email.com>");
-    mail.addFrom("some dispaly name <somefromadd@email.com>");
+    mail.setRecipient("some display name <sometoadd@email.com>");
+    mail.setFrom("some dispaly name <somefromadd@email.com>");
     mail.send("A text only message", "<html><body><p>An <b>html</b> message</p></body></html>" );
 
     return ok(index.render("Your new application is ready."));

--- a/mailer/src/main/scala/com/typesafe/plugin/MailerApiJavaInterop.java
+++ b/mailer/src/main/scala/com/typesafe/plugin/MailerApiJavaInterop.java
@@ -16,20 +16,20 @@ public interface MailerApiJavaInterop {
    *
    * @param ccRecipients
    */
-  public MailerAPI addCc(String... ccRecipients);
+  public MailerAPI setCc(String... ccRecipients);
 
   /**
    * Adds an email recipient in BCC.
    *
    * @param bccRecipients
    */
-  public MailerAPI addBcc(String... bccRecipients);
+  public MailerAPI setBcc(String... bccRecipients);
 
   /**
    * Adds an email recipient ("to" addressee).
    *
    * @param recipients
    */
-  public  MailerAPI addRecipient(String... recipients); 
+  public  MailerAPI setRecipient(String... recipients); 
   
 }

--- a/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
+++ b/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
@@ -20,7 +20,7 @@ trait MailerAPI extends MailerApiJavaInterop {
    *
    * @param from
    */
-  def addFrom(from: String): MailerAPI 
+  def setFrom(from: String): MailerAPI 
 
   /**
    * Defines the "reply to" email address.
@@ -115,7 +115,7 @@ trait MailerBuilder extends MailerAPI {
    *
    * @param from
    */
-  def addFrom(from: String): MailerAPI = {
+  def setFrom(from: String): MailerAPI = {
     context.get += ("from"-> List(from))
     this
   }
@@ -125,7 +125,7 @@ trait MailerBuilder extends MailerAPI {
    *
    * @param ccRecipients
    */
-  def addCc(ccRecipients: String*): MailerAPI = {
+  def setCc(ccRecipients: String*): MailerAPI = {
     context.get += ("ccRecipients"->ccRecipients.toList)
     this
   }
@@ -135,7 +135,7 @@ trait MailerBuilder extends MailerAPI {
    *
    * @param bccRecipients
    */
-  def addBcc(bccRecipients: String*): MailerAPI = {
+  def setBcc(bccRecipients: String*): MailerAPI = {
     context.get += ("bccRecipients"->bccRecipients.toList)
     this
   }
@@ -145,7 +145,7 @@ trait MailerBuilder extends MailerAPI {
    *
    * @param recipients
    */
-  def addRecipient(recipients: String*): MailerAPI = {
+  def setRecipient(recipients: String*): MailerAPI = {
     context.get += ("recipients"->recipients.toList)
     this
   }


### PR DESCRIPTION
When applied, this commit fixes weird behavior that can occur when someone calls addRecipient multiple times, expecting this would add multiple recipients. One would then replace the recipient with the last 'added' one and lots of people wouldn't get their beloved e-mails. This closed #56
