### PR TITLE
Play 2.2.x compatible statsdFilter

### DIFF
--- a/statsd/src/main/scala/play/modules/statsd/api/StatsdFilter.scala
+++ b/statsd/src/main/scala/play/modules/statsd/api/StatsdFilter.scala
@@ -69,28 +69,18 @@ class StatsdFilter extends EssentialFilter {
         Statsd.increment(totalPrefix + "error")
       }
 
-      def recordStats(result: Result): Result = {
-        result match {
-          case async: AsyncResult => {
-            async.result.onFailure {
-              case t => handleError
-            }
-            async.map(recordStats)
-          }
-          case plain: PlainResult => {
-            val time = System.currentTimeMillis() - start
-            Statsd.timing(key, time)
-            Statsd.timing(totalPrefix + "time", time)
-            val status = plain.header.status
-            Statsd.increment(totalPrefix + status)
-            if (status >= 500) {
-              Statsd.increment(totalPrefix + "error")
-            } else {
-              Statsd.increment(totalPrefix + "success")
-            }
-            plain
-          }
+      def recordStats(result: SimpleResult): SimpleResult = {
+        val time = System.currentTimeMillis() - start
+        Statsd.timing(key, time)
+        Statsd.timing(totalPrefix + "time", time)
+        val status = result.header.status
+        Statsd.increment(totalPrefix + status)
+        if (status >= 500) {
+          Statsd.increment(totalPrefix + "error")
+        } else {
+          Statsd.increment(totalPrefix + "success")
         }
+        result
       }
 
       // Invoke the action


### PR DESCRIPTION
Due to changes in the play framework statsdFilter is incompatible with play 2.2.

This change fixes the incompatibility, altough it's not backwards compatible with play 2.1
