### PR TITLE
Fix serialization bugs in RedisPlugin and add support for serializing Results

### DIFF
--- a/redis/project/Build.scala
+++ b/redis/project/Build.scala
@@ -24,7 +24,6 @@ object MinimalBuild extends Build {
     libraryDependencies += "biz.source_code" % "base64coder" % "2010-12-19",
     libraryDependencies += "com.typesafe" %% "play-plugins-util" % buildVersion,
     libraryDependencies += "com.typesafe.play" %% "play-cache" % buildVersion % "provided",
-    libraryDependencies += "org.sedis" % "sedis_2.10.0" % "1.1.1",
-    libraryDependencies += "commons-io" % "commons-io" % "2.4"
+    libraryDependencies += "org.sedis" % "sedis_2.10.0" % "1.1.1"
   )
 }

--- a/redis/project/Build.scala
+++ b/redis/project/Build.scala
@@ -24,6 +24,7 @@ object MinimalBuild extends Build {
     libraryDependencies += "biz.source_code" % "base64coder" % "2010-12-19",
     libraryDependencies += "com.typesafe" %% "play-plugins-util" % buildVersion,
     libraryDependencies += "com.typesafe.play" %% "play-cache" % buildVersion % "provided",
-    libraryDependencies += "org.sedis" % "sedis_2.10.0" % "1.1.1"
+    libraryDependencies += "org.sedis" % "sedis_2.10.0" % "1.1.1",
+    libraryDependencies += "commons-io" % "commons-io" % "2.4"
   )
 }

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -101,23 +101,23 @@ class RedisPlugin(app: Application) extends CachePlugin {
      try {
        val baos = new ByteArrayOutputStream()
        var prefix = "oos"
-       if (value.getClass.isInstanceOf[Serializable]) {
+       if (value.isInstanceOf[Serializable]) {
           oos = new ObjectOutputStream(baos)
           oos.writeObject(value)
           oos.flush()
-       } else if (value.getClass.isInstanceOf[String]) {
+       } else if (value.isInstanceOf[String]) {
           dos = new DataOutputStream(baos)
           dos.writeUTF(value.asInstanceOf[String])
           prefix = "string"
-       } else if (value.getClass.isInstanceOf[Int]) {
+       } else if (value.isInstanceOf[Int]) {
           dos = new DataOutputStream(baos)
           dos.writeInt(value.asInstanceOf[Int])
           prefix = "int"
-       } else if (value.getClass.isInstanceOf[Long]) {
+       } else if (value.isInstanceOf[Long]) {
           dos = new DataOutputStream(baos)
           dos.writeLong(value.asInstanceOf[Long])
           prefix = "long"
-       } else if (value.getClass.isInstanceOf[Boolean]) {
+       } else if (value.isInstanceOf[Boolean]) {
           dos = new DataOutputStream(baos)
           dos.writeBoolean(value.asInstanceOf[Boolean])
           prefix = "boolean"

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -10,6 +10,7 @@ import java.net.URI
 import biz.source_code.base64Coder._
 import org.apache.commons.lang3.builder._
 import org.apache.commons.pool.impl.GenericObjectPool
+import play.api.mvc.Result
 
 /**
  * provides a redis client and a CachePlugin implementation

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -10,6 +10,7 @@ import java.net.URI
 import biz.source_code.base64Coder._
 import org.apache.commons.lang3.builder._
 import org.apache.commons.pool.impl.GenericObjectPool
+import org.apache.commons.io.input.ClassLoaderObjectInputStream
 
 /**
  * provides a redis client and a CachePlugin implementation
@@ -156,7 +157,7 @@ class RedisPlugin(app: Application) extends CachePlugin {
                 val b = Base64Coder.decode(data.last)
                 data.head match {
                   case "oos" =>
-                      ois = new ObjectInputStream(new ByteArrayInputStream(b))
+                      ois = new ClassLoaderObjectInputStream(play.api.Play.current.classloader, new ByteArrayInputStream(b))
                       val r  = ois.readObject()
                       Some(r)
                   case "string" =>

--- a/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
@@ -1,0 +1,56 @@
+package com.typesafe.plugin
+
+import play.api.libs.iteratee._
+import play.api.libs.concurrent._
+import play.api.mvc._
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class RedisResult(status: Int,
+                       headers: Map[String, String],
+                       body: Array[Byte]) extends Serializable
+
+object RedisResult
+{
+  /**
+   * Extracts the content as bytes.
+   * From play/api/test/Helpers.scala
+   */
+  def contentAsBytes(of: Result): Array[Byte] = of match {
+    case r @ SimpleResult(_, bodyEnumerator) => {
+      var readAsBytes = Enumeratee.map[r.BODY_CONTENT](r.writeable.transform(_)).transform(Iteratee.consume[Array[Byte]]())
+      bodyEnumerator(readAsBytes).flatMap(_.run).value1.get
+    }
+    case p:PlainResult => Array[Byte]()
+    case AsyncResult(p) => contentAsBytes(p.await.get)
+  }
+
+  /**
+   * Extracts the Status code of this Result value.
+   * From play/api/test/Helpers.scala
+   */
+  def status(of: Result): Int = of match {
+    case PlainResult(status, _) => status
+    case AsyncResult(p) => status(p.await.get)
+  }
+
+  /**
+   * Extracts all Headers of this Result value.
+   * From play/api/test/Helpers.scala
+   */
+  def headers(of: Result): Map[String, String] = of match {
+    case PlainResult(_, headers) => headers
+    case AsyncResult(p) => headers(p.await.get)
+  }
+
+  def wrapResult(result:Result):RedisResult = {
+    RedisResult(status(result),
+                 headers(result),
+                 contentAsBytes(result))
+  }
+
+  def unwrapResult(cachedResult:RedisResult) = {
+    SimpleResult(ResponseHeader(cachedResult.status, cachedResult.headers),
+                 Enumerator(cachedResult.body))
+  }
+}

--- a/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
@@ -7,6 +7,7 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
+@SerialVersionUID(7122652360758747455L)
 case class RedisResult(status: Int,
                        headers: Map[String, String],
                        body: Array[Byte]) extends Serializable


### PR DESCRIPTION
This fixes a few problems in RedisPlugin:
1. The use of "value.getClass.isInstanceOf[T]" to identify various types for serialization was incorrect; it should be "value.isInstanceOf[T]"
2. When run under the dynamic reloadable ClassLoader used by "play run" development mode, ObjectInputStream would fail to deserialize objects. According to jroper, it is not safe to call Class.forName in Play code since the dynamic classloader may be in use. The fix is to subclass ObjectInputStream and override resolveClass to pass in the Play classloader.
3. The Cached decorator would not work with RedisPlugin because Result/SimpleResult/etc. are not serializable. Making them serializable would be difficult since they contain Enumerators, so I fixed this by converting Results to a simple case class RedisResult which contains a simple binary array for the response body.
