### PR TITLE
Simplify support for caching results in RedisPlugin

### DIFF
--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -101,19 +101,24 @@ class RedisPlugin(app: Application) extends CachePlugin {
       value match {
         case simpleResult:SimpleResult =>
           RedisResult.wrapResult(simpleResult).map {
-            redisResult => set_(key, redisResult, expiration, "result")
+            redisResult => set_(key, redisResult, expiration)
           }
         case _ => set_(key, value, expiration)
       }
     }      
 
-    def set_(key: String, value: Any, expiration: Int, defaultPrefix:String = "oos") {
+    def set_(key: String, value: Any, expiration: Int) {
      var oos: ObjectOutputStream = null
      var dos: DataOutputStream = null
      try {
        val baos = new ByteArrayOutputStream()
-       var prefix = defaultPrefix
-       if (value.isInstanceOf[Serializable]) {
+       var prefix = "oos"
+       if (value.isInstanceOf[RedisResult]) {
+          oos = new ObjectOutputStream(baos)
+          oos.writeObject(value)
+          oos.flush()
+          prefix = "result"
+       } else if (value.isInstanceOf[Serializable]) {
           oos = new ObjectOutputStream(baos)
           oos.writeObject(value)
           oos.flush()

--- a/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisResult.scala
@@ -1,11 +1,9 @@
 package com.typesafe.plugin
 
 import play.api.libs.iteratee._
-import play.api.libs.concurrent._
 import play.api.mvc._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration._
 
 @SerialVersionUID(7122652360758747455L)
 case class RedisResult(status: Int,
@@ -14,40 +12,14 @@ case class RedisResult(status: Int,
 
 object RedisResult
 {
-  /**
-   * Extracts the content as bytes.
-   * From play/api/test/Helpers.scala
-   */
-  def contentAsBytes(of: Result): Array[Byte] = of match {
-    case r:SimpleResult => {
-      Await.result(r.body |>>> Iteratee.consume[Array[Byte]](), 1000 millis)
+  def wrapResult(result:SimpleResult):Future[RedisResult] = {
+    val contentAsBytesFuture = result.body |>>> Iteratee.consume[Array[Byte]]()
+    contentAsBytesFuture.map {
+      contentAsBytes =>
+        RedisResult(result.header.status,
+                    result.header.headers,
+                    contentAsBytes)
     }
-    case p:PlainResult => Array[Byte]()
-    case AsyncResult(p) => contentAsBytes(p.await.get)
-  }
-
-  /**
-   * Extracts the Status code of this Result value.
-   * From play/api/test/Helpers.scala
-   */
-  def status(of: Result): Int = of match {
-    case PlainResult(status, _) => status
-    case AsyncResult(p) => status(p.await.get)
-  }
-
-  /**
-   * Extracts all Headers of this Result value.
-   * From play/api/test/Helpers.scala
-   */
-  def headers(of: Result): Map[String, String] = of match {
-    case PlainResult(_, headers) => headers
-    case AsyncResult(p) => headers(p.await.get)
-  }
-
-  def wrapResult(result:Result):RedisResult = {
-    RedisResult(status(result),
-                 headers(result),
-                 contentAsBytes(result))
   }
 
   def unwrapResult(cachedResult:RedisResult) = {


### PR DESCRIPTION
This simplifies the change I made earlier to cache Results in RedisPlugin.
- Since SimpleResult will be the only supported type of Result in the future, only support serializing SimpleResult and remove support for the deprecated PlainResult and AsyncResult types
- Eliminate use of blocking "await"; use futures to asynchronously obtain the bytes of a SimpleResult to be cached.
