### PR TITLE
Redis: Added configuration option to use a specific database number

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -20,7 +20,7 @@ val o = play.api.cache.Cache.getAs[String]("mykey")
 
 #### Configurable
 
-* Point to your Redis server using configuration settings  ```redis.host```, ```redis.port``` and ```redis.password``` (defaults: ```localhost```, ```6379``` and ```null``` )
+* Point to your Redis server using configuration settings  ```redis.host```, ```redis.port```,  ```redis.password``` and ```redis.database``` (defaults: ```localhost```, ```6379```, ```null``` and ```0```)
 * Alternatively, specify a URI-based configuration using ```redis.uri``` (for example: ```redis.uri="redis://user:password@localhost:6379"```).
 * Set the timeout in milliseconds using ```redis.timeout``` (default is 2000).
 * Configure any aspect of the connection pool. See [the documentation for commons-pool ```GenericObjectPool```](http://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool/impl/GenericObjectPool.html), the underlying pool implementation, for more information on each setting.

--- a/redis/project/Build.scala
+++ b/redis/project/Build.scala
@@ -10,7 +10,7 @@ object MinimalBuild extends Build {
   lazy val repo = if (buildVersion.endsWith("SNAPSHOT")) typesafeSnapshot else typesafe  
   lazy val pk11 = "pk11 repo" at "http://pk11-scratch.googlecode.com/svn/trunk"
   lazy val root = Project(id = "play-plugins-redis", base = file("."), settings = Project.defaultSettings).settings(
-    version := "2.2.0",
+    version := "2.2.2",
     scalaVersion := "2.10.2",
     publishTo <<= (version) { version: String =>
                 val nexus = "https://private-repo.typesafe.com/typesafe/"

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -38,15 +38,18 @@ class RedisPlugin(app: Application) extends CachePlugin {
  private lazy val timeout = app.configuration.getInt("redis.timeout")
                             .getOrElse(2000)
 
+ private lazy val database = app.configuration.getInt("redis.database")
+                          	.getOrElse(0)
+
 
  /**
   * provides access to the underlying jedis Pool
   */
  lazy val jedisPool = {
    val poolConfig = createPoolConfig(app)
-   Logger.info(s"Redis Plugin enabled. Connecting to Redis on ${host}:${port} with timeout ${timeout}.")
+   Logger.info(s"Redis Plugin enabled. Connecting to Redis on ${host}:${port} to ${database} with timeout ${timeout}.")
    Logger.info("Redis Plugin pool configuration: " + new ReflectionToStringBuilder(poolConfig).toString())
-   new JedisPool(poolConfig, host, port, timeout, password)
+   new JedisPool(poolConfig, host, port, timeout, password, database)
  }
 
   /**


### PR DESCRIPTION
Added a simple configuration to use a specific database number for a given redis instance. Was only able to use Database number 0. 

Now, you can specify the database to use with the configuration key `redis.database=1`  Defaults to 0.

Updated the configuration, logging, and readme. Thanks for the awesome plugin. Just wanted to share the new feature.
