### PR TITLE
Updated versions in documentation for redis plugin

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -70,8 +70,8 @@ pool.withJedisClient { client =>
 
 * add 
 
-play 2.0.x:
-```"com.typesafe" %% "play-plugins-redis" % "2.0.4"``` to your dependencies
+play 2.2.x:
+```"com.typesafe" %% "play-plugins-redis" % "2.2.0"``` to your dependencies
 
 * create a file called ```play.plugins``` in your ```app/conf``` directory
 


### PR DESCRIPTION
I've updated documentation to reflect current versions. 2.0.4 doesn't even exist in Typesafe repo anymore, so documentation on master is not really useful.
