### PR TITLE
Use def for jedis pol

### DIFF
--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -45,7 +45,7 @@ class RedisPlugin(app: Application) extends CachePlugin {
  /**
   * provides access to the underlying jedis Pool
   */
- lazy val jedisPool = {
+ def jedisPool = {
    val poolConfig = createPoolConfig(app)
    Logger.info(s"Redis Plugin enabled. Connecting to Redis on ${host}:${port} to ${database} with timeout ${timeout}.")
    Logger.info("Redis Plugin pool configuration: " + new ReflectionToStringBuilder(poolConfig).toString())


### PR DESCRIPTION
Tests will fail if run together. To fix, use def for jedis pool instead of val.
