### PR TITLE
Updated Redis for Scala 2.11 compatibility

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -23,11 +23,11 @@ val o = play.api.cache.Cache.getAs[String]("mykey")
 * Point to your Redis server using configuration settings  ```redis.host```, ```redis.port```,  ```redis.password``` and ```redis.database``` (defaults: ```localhost```, ```6379```, ```null``` and ```0```)
 * Alternatively, specify a URI-based configuration using ```redis.uri``` (for example: ```redis.uri="redis://user:password@localhost:6379"```).
 * Set the timeout in milliseconds using ```redis.timeout``` (default is 2000).
-* Configure any aspect of the connection pool. See [the documentation for commons-pool ```GenericObjectPool```](http://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool/impl/GenericObjectPool.html), the underlying pool implementation, for more information on each setting.
+* Configure any aspect of the connection pool. See [the documentation for commons-pool2 ```GenericObjectPoolConfig```](https://commons.apache.org/proper/commons-pool/apidocs/org/apache/commons/pool2/impl/GenericObjectPoolConfig.html), the underlying pool implementation, for more information on each setting.
     * redis.pool.maxIdle
     * redis.pool.minIdle
-    * redis.pool.maxActive
-    * redis.pool.maxWait
+    * redis.pool.maxTotal
+    * redis.pool.maxWaitMillis
     * redis.pool.testOnBorrow
     * redis.pool.testOnReturn
     * redis.pool.testWhileIdle
@@ -36,7 +36,7 @@ val o = play.api.cache.Cache.getAs[String]("mykey")
     * redis.pool.minEvictableIdleTimeMillis
     * redis.pool.softMinEvictableIdleTimeMillis
     * redis.pool.lifo
-    * redis.pool.whenExhaustedAction (valid options: "fail", "block" (default), "grow")
+    * redis.pool.blockWhenExhausted
 
 
 #### Allows direct access to Jedis and Sedis: 
@@ -75,7 +75,6 @@ play < 2.3.x:
 
 play = 2.3.x:
 ```"com.typesafe.play.plugins" %% "play-plugins-redis" % "2.3.0"``` to your dependencies
-* Please note: only compatible with Scala 2.10 until sedis is recompiled with Scala 2.11
 
 * create a file called ```play.plugins``` in your ```app/conf``` directory
 

--- a/redis/build.sbt
+++ b/redis/build.sbt
@@ -1,33 +1,31 @@
 import scala.Some
 
 name := "play-plugins-redis"
-    
+
 organization := "com.typesafe.play.plugins"
 
 version := "2.3.0"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.2"
 
-//scalaVersion := "2.11.1"
-
-//crossScalaVersions := Seq("2.11.1", "2.10.4")
+crossScalaVersions := Seq("2.11.2", "2.10.4")
 
 libraryDependencies ++= Seq(
   "com.typesafe.play"         %% "play"               % "2.3.0"     % "provided",
   "biz.source_code"           %  "base64coder"        % "2010-12-19",
   "com.typesafe.play"         %% "play-cache"         % "2.3.0",
   "com.typesafe.play.plugins" %% "play-plugins-util"  % "2.3.0",
-  "org.sedis"                 %  "sedis_2.10.0"       % "1.1.1"
+  "org.sedis"                 %  "sedis_2.11"         % "1.2.2"
 )
 
 resolvers += "pk11 repo" at "http://pk11-scratch.googlecode.com/svn/trunk"
 
 publishTo <<= (version) { version: String =>
   val nexus = "https://private-repo.typesafe.com/typesafe/"
-  if (version.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "maven-snapshots/") 
+  if (version.trim.endsWith("SNAPSHOT")) Some("snapshots" at nexus + "maven-snapshots/")
   else                                   Some("releases"  at nexus + "maven-releases/")
 }
- 
+
 javacOptions ++= Seq("-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-encoding", "UTF-8")
 
 scalacOptions += "-deprecation"

--- a/redis/build.sbt
+++ b/redis/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   "biz.source_code"           %  "base64coder"        % "2010-12-19",
   "com.typesafe.play"         %% "play-cache"         % "2.3.0",
   "com.typesafe.play.plugins" %% "play-plugins-util"  % "2.3.0",
-  "org.sedis"                 %  "sedis_2.11"         % "1.2.2"
+  "org.sedis"                 %%  "sedis"             % "1.2.2"
 )
 
 resolvers += "pk11 repo" at "http://pk11-scratch.googlecode.com/svn/trunk"

--- a/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
+++ b/redis/src/main/scala/com/typesafe/plugin/RedisPlugin.scala
@@ -11,7 +11,7 @@ import biz.source_code.base64Coder._
 import org.apache.commons.lang3.builder._
 import play.api.mvc.Result
 import scala.concurrent.ExecutionContext.Implicits.global
-import org.apache.commons.pool.impl.GenericObjectPool
+import org.apache.commons.pool2.impl.GenericObjectPool
 
 /**
  * provides a redis client and a CachePlugin implementation
@@ -59,25 +59,19 @@ class RedisPlugin(app: Application) extends CachePlugin {
 
  private def createPoolConfig(app: Application) : JedisPoolConfig = {
    val poolConfig : JedisPoolConfig = new JedisPoolConfig()
-   app.configuration.getInt("redis.pool.maxIdle").map { poolConfig.maxIdle = _ }
-   app.configuration.getInt("redis.pool.minIdle").map { poolConfig.minIdle = _ }
-   app.configuration.getInt("redis.pool.maxActive").map { poolConfig.maxActive = _ }
-   app.configuration.getInt("redis.pool.maxWait").map { poolConfig.maxWait = _ }
-   app.configuration.getBoolean("redis.pool.testOnBorrow").map { poolConfig.testOnBorrow = _ }
-   app.configuration.getBoolean("redis.pool.testOnReturn").map { poolConfig.testOnReturn = _ }
-   app.configuration.getBoolean("redis.pool.testWhileIdle").map { poolConfig.testWhileIdle = _ }
-   app.configuration.getLong("redis.pool.timeBetweenEvictionRunsMillis").map { poolConfig.timeBetweenEvictionRunsMillis = _ }
-   app.configuration.getInt("redis.pool.numTestsPerEvictionRun").map { poolConfig.numTestsPerEvictionRun = _ }
-   app.configuration.getLong("redis.pool.minEvictableIdleTimeMillis").map { poolConfig.minEvictableIdleTimeMillis = _ }
-   app.configuration.getLong("redis.pool.softMinEvictableIdleTimeMillis").map { poolConfig.softMinEvictableIdleTimeMillis = _ }
-   app.configuration.getBoolean("redis.pool.lifo").map { poolConfig.lifo = _ }
-    app.configuration.getString("redis.pool.whenExhaustedAction").map { setting =>
-      poolConfig.whenExhaustedAction = setting match {
-        case "fail"  | "0" => GenericObjectPool.WHEN_EXHAUSTED_FAIL
-        case "block" | "1" => GenericObjectPool.WHEN_EXHAUSTED_BLOCK
-        case "grow"  | "2" => GenericObjectPool.WHEN_EXHAUSTED_FAIL
-      }
-    }
+   app.configuration.getInt("redis.pool.maxIdle").map { poolConfig.setMaxIdle(_) }
+   app.configuration.getInt("redis.pool.minIdle").map { poolConfig.setMinIdle(_) }
+   app.configuration.getInt("redis.pool.maxTotal").map { poolConfig.setMaxTotal(_) }
+   app.configuration.getInt("redis.pool.maxWaitMillis").map { poolConfig.setMaxWaitMillis(_) }
+   app.configuration.getBoolean("redis.pool.testOnBorrow").map { poolConfig.setTestOnBorrow(_) }
+   app.configuration.getBoolean("redis.pool.testOnReturn").map { poolConfig.setTestOnReturn(_) }
+   app.configuration.getBoolean("redis.pool.testWhileIdle").map { poolConfig.setTestWhileIdle(_) }
+   app.configuration.getLong("redis.pool.timeBetweenEvictionRunsMillis").map { poolConfig.setTimeBetweenEvictionRunsMillis(_) }
+   app.configuration.getInt("redis.pool.numTestsPerEvictionRun").map { poolConfig.setNumTestsPerEvictionRun(_) }
+   app.configuration.getLong("redis.pool.minEvictableIdleTimeMillis").map { poolConfig.setMinEvictableIdleTimeMillis(_) }
+   app.configuration.getLong("redis.pool.softMinEvictableIdleTimeMillis").map { poolConfig.setSoftMinEvictableIdleTimeMillis(_) }
+   app.configuration.getBoolean("redis.pool.lifo").map { poolConfig.setLifo(_) }
+   app.configuration.getBoolean("redis.pool.blockWhenExhausted").map { poolConfig.setBlockWhenExhausted(_) }
    poolConfig
  }
 


### PR DESCRIPTION
I haven't updated the version from `2.3.0` or any of the other play dependencies. I thought I would leave that for the maintainers to decide.
