### PR TITLE
Mailer Bugfix: Correctly set charset BEFORE setting the html/text body

### DIFF
--- a/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
+++ b/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
@@ -227,8 +227,7 @@ class CommonsMailer(smtpHost: String,smtpPort: Int,smtpSsl: Boolean, smtpTls: Bo
    * @return
    */
   def send(bodyText: String, bodyHtml: String): Unit = {
-    val email = createEmailer(bodyText,bodyHtml)
-    email.setCharset(e("charset").headOption.getOrElse("utf-8"))
+    val email = createEmailer(bodyText,bodyHtml,e("charset").headOption.getOrElse("utf-8"))
     email.setSubject(e("subject").headOption.getOrElse(""))
     e("from").foreach(setAddress(_) { (address, name) => email.setFrom(address, name) })
     e("replyTo").foreach(setAddress(_) { (address, name) => email.addReplyTo(address, name) })
@@ -278,15 +277,23 @@ class CommonsMailer(smtpHost: String,smtpPort: Int,smtpSsl: Boolean, smtpTls: Bo
    * @param bodyHtml
    * @return
    */
-  private def createEmailer(bodyText: String, bodyHtml: String): MultiPartEmail = {
+  private def createEmailer(bodyText: String, bodyHtml: String, charset: String): MultiPartEmail = {
     if (bodyHtml == null || bodyHtml == "") {
       val e = new MultiPartEmail()
+      e.setCharset(charset)
       e.setMsg(bodyText)
       e
-    } else if (bodyText == null || bodyText == "")
-        new HtmlEmail().setHtmlMsg(bodyHtml)
-      else
-        new HtmlEmail().setHtmlMsg(bodyHtml).setTextMsg(bodyText)
+    } else if (bodyText == null || bodyText == "") {
+        val e = new HtmlEmail()
+        e.setCharset(charset)
+        e.setHtmlMsg(bodyHtml)
+        e
+    } else {
+        val e = new HtmlEmail()
+        e.setCharset(charset)
+        e.setHtmlMsg(bodyHtml).setTextMsg(bodyText)
+        e
+    }
   }
 
 }


### PR DESCRIPTION
Running following code:

```
MailerAPI mail = play.Play.application().plugin(MailerPlugin.class).email();
mail.setSubject("Testing Charset");
mail.setRecipient("recipient@email.com");
mail.setFrom("noreply@email.com");
mail.send("Test");
```

sends out an e-mail with the wrong charset `us-ascii` instead of `utf-8`:

```
Content-Type: text/plain; charset=us-ascii
```

That's because right now `setCharset` is called **after** the text/html body was set. That's wrong.
Looking at the [API Documentation for `setCharset`](http://commons.apache.org/proper/commons-email/apidocs/org/apache/commons/mail/Email.html#setCharset%28java.lang.String%29) it says

```
...  Please note that you should set the charset before adding the message content.
```

Running the above code with my fix it correctly sends out an e-mail with the correct charset:

```
Content-Type: text/plain; charset=UTF-8
```

Someone else also [already experienced this bug](https://github.com/typesafehub/play-plugins/issues/33#issuecomment-36029130).
