### PR TITLE
Redirect javax.mail logging to play.Logger

### DIFF
--- a/mailer/README.md
+++ b/mailer/README.md
@@ -20,6 +20,7 @@ smtp.ssl (defaults to no)
 smtp.tls (defaults to no)
 smtp.user (optional)
 smtp.password (optional)
+smtp.debug (defaults to no)
 ```
 
 

--- a/mailer/README.md
+++ b/mailer/README.md
@@ -20,7 +20,7 @@ smtp.ssl (defaults to no)
 smtp.tls (defaults to no)
 smtp.user (optional)
 smtp.password (optional)
-smtp.debug (defaults to no)
+smtp.debug (defaults to no, to take effect you also need to set the log level to "DEBUG" for the application logger)
 ```
 
 

--- a/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
+++ b/mailer/src/main/scala/com/typesafe/plugin/MailerPlugin.scala
@@ -215,7 +215,7 @@ trait MailerBuilder extends MailerAPI {
  *  and also Justin Long's gist)
  */
 
-class CommonsMailer(smtpHost: String,smtpPort: Int,smtpSsl: Boolean, smtpTls: Boolean, smtpUser: Option[String], smtpPass: Option[String]) extends MailerBuilder {
+class CommonsMailer(smtpHost: String,smtpPort: Int,smtpSsl: Boolean, smtpTls: Boolean, smtpUser: Option[String], smtpPass: Option[String], debugMode: Boolean) extends MailerBuilder {
 
   /**
    * Sends an email based on the provided data. 
@@ -246,7 +246,7 @@ class CommonsMailer(smtpHost: String,smtpPort: Int,smtpSsl: Boolean, smtpTls: Bo
     }
     email.setStartTLSEnabled(smtpTls)
     for(u <- smtpUser; p <- smtpPass) yield email.setAuthenticator(new DefaultAuthenticator(u, p))
-    email.setDebug(false)
+    email.setDebug(debugMode)
     email.send
     context.get.clear()
   }
@@ -351,7 +351,8 @@ class CommonsMailerPlugin(app: play.api.Application) extends MailerPlugin {
     val smtpTls = app.configuration.getBoolean("smtp.tls").getOrElse(false)
     val smtpUser = app.configuration.getString("smtp.user")
     val smtpPassword = app.configuration.getString("smtp.password")
-    new CommonsMailer(smtpHost, smtpPort, smtpSsl, smtpTls, smtpUser, smtpPassword)
+    val debugMode = app.configuration.getBoolean("smtp.debug").getOrElse(false)
+    new CommonsMailer(smtpHost, smtpPort, smtpSsl, smtpTls, smtpUser, smtpPassword, debugMode)
   }
 
   override lazy val enabled = {


### PR DESCRIPTION
This PR enhances the work/commit done in PR #109 so when setting `smtp.debug=true` the debug information written by `javax.mail` will be redirected to the Play Logger.
By default javax.mail [writes debug information to System.out](http://www.oracle.com/technetwork/java/faq-135477.html#debug). If you are interested you can dig into [the source of javax.mail.Session](http://grepcode.com/file/repo1.maven.org/maven2/com.sun.mail/javax.mail/1.4.4/javax/mail/Session.java) to see how it handles logging (`getDebugOut`, `setDebugOut` and `pr` are the interesting methods).

This PR is based on [this question on stackoverflow](http://stackoverflow.com/questions/2118370).
