### PR TITLE
Fixed group ID for the Play 2.4 version

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -101,8 +101,9 @@ play = 2.3.x:
  ```
 
 play = 2.4.x:
-```"com.typesafe" %% "play-modules-redis" % "2.4.0"``` to your dependencies
-
+```"com.typesafe.play.modules" %% "play-modules-redis" % "2.4.0"``` to your dependencies
+and you'll probably need to add this resolver too to resolve Sedis (see [issue](https://github.com/typesafehub/play-plugins/issues/141)):
+```resolvers += "google-sedis-fix" at "http://pk11-scratch.googlecode.com/svn/trunk"```
 * The default cache module (EhCache) will be used for all non-named cache UNLESS this module (RedisModule) is the only cache module that was loaded. If this module is the only cache module being loaded, it will work as expected on named and non-named cache. To disable the default cache module so that this Redis Module can be the default cache you must put this in your configuration:
  
  ```


### PR DESCRIPTION
It's here:

http://mvnrepository.com/artifact/com.typesafe.play.modules/play-modules-redis_2.11
