### PR TITLE
`getOrElse` double prefixing fix

### DIFF
--- a/redis/src/main/scala/com/typesafe/play/redis/RedisCacheApi.scala
+++ b/redis/src/main/scala/com/typesafe/play/redis/RedisCacheApi.scala
@@ -45,9 +45,9 @@ class RedisCacheApi @Inject()(val namespace: String, sedisPool: Pool, classLoade
   }
 
   def getOrElse[A: ClassTag](userKey: String, expiration: Duration)(orElse: => A) = {
-    get[A](namespacedKey(userKey)).getOrElse {
+    get[A](userKey).getOrElse {
       val value = orElse
-      set(namespacedKey(userKey), value, expiration)
+      set(userKey, value, expiration)
       value
     }
   }


### PR DESCRIPTION
Using `namespacedKey` in `getOrElse` results in keys being double-prefixed because both `get` and `set` already do that.
