### PR TITLE
Update for Play 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: scala
 env:
   - PROJECT=statsd
   - PROJECT=redis
-script: cd util && sbt +publish-local && cd ../$PROJECT && sbt +test
+script: ./run-tests-travis.sh
 matrix:
   exclude:
   - jdk: openjdk6

--- a/redis/README.md
+++ b/redis/README.md
@@ -67,7 +67,7 @@ pool.withJedisClient { client =>
   Option[String] single = Dress.up(client).get("single")
 }
 ```
-play = 2.4.x:
+play = 2.4.x and 2.5.x:
 Because the underlying Sedis Pool was injected for the cache module to use, you can just inject the sedis Pool yourself, something like this:
 
 ```scala
@@ -94,13 +94,13 @@ class TryIt extends Controller {
 }
 ```
 
-The Play 2.4.x module also supports compile time DI via RedisCacheComponents. Mix this in with your custom application loader just like you would if you were using EhCacheComponents from the reference cache module.
+The Play 2.4.x and 2.5.x module also supports compile time DI via RedisCacheComponents. Mix this in with your custom application loader just like you would if you were using EhCacheComponents from the reference cache module.
 
 
 
 # How to install
 
-* add 
+* add
 
 play < 2.3.x:
 ```"com.typesafe" %% "play-plugins-redis" % "2.0.4"``` to your dependencies
@@ -120,16 +120,32 @@ play = 2.3.x:
  ```
 
 play = 2.4.x:
-```"com.typesafe.play.modules" %% "play-modules-redis" % "2.4.0"``` to your dependencies
+```"com.typesafe.play.modules" %% "play-modules-redis" % "2.4.1"``` to your dependencies
 and you'll probably need to add this resolver too to resolve Sedis (see [issue](https://github.com/typesafehub/play-plugins/issues/141)):
 ```resolvers += "google-sedis-fix" at "http://pk11-scratch.googlecode.com/svn/trunk"```
 * The default cache module (EhCache) will be used for all non-named cache UNLESS this module (RedisModule) is the only cache module that was loaded. If this module is the only cache module being loaded, it will work as expected on named and non-named cache. To disable the default cache module so that this Redis Module can be the default cache you must put this in your configuration:
- 
+
  ```
  play.modules.disabled = ["play.api.cache.EhCacheModule"]
  ```
 
 * This module supports play 2.4 NamedCaches through key namespacing on a single Sedis pool. To add additional namepsaces besides the default (play), the configuration would look like such:
+
+ ```
+ play.cache.redis.bindCaches = ["db-cache", "user-cache", "session-cache"]
+ ```
+
+play = 2.5.x:
+```"com.typesafe.play.modules" %% "play-modules-redis" % "2.5.0"``` to your dependencies
+and you'll probably need to add this resolver too to resolve Sedis (see [issue](https://github.com/typesafehub/play-plugins/issues/141)):
+```resolvers += "google-sedis-fix" at "http://pk11-scratch.googlecode.com/svn/trunk"```
+* The default cache module (EhCache) will be used for all non-named cache UNLESS this module (RedisModule) is the only cache module that was loaded. If this module is the only cache module being loaded, it will work as expected on named and non-named cache. To disable the default cache module so that this Redis Module can be the default cache you must put this in your configuration:
+
+ ```
+ play.modules.disabled = ["play.api.cache.EhCacheModule"]
+ ```
+
+* This module supports play 2.5 NamedCaches through key namespacing on a single Sedis pool. To add additional namepsaces besides the default (play), the configuration would look like such:
 
  ```
  play.cache.redis.bindCaches = ["db-cache", "user-cache", "session-cache"]

--- a/redis/build.sbt
+++ b/redis/build.sbt
@@ -1,18 +1,17 @@
 name := "play-modules-redis"
 organization := "com.typesafe.play.modules"
 
-scalaVersion := "2.11.6"
-crossScalaVersions := Seq("2.11.6", "2.10.5")
+scalaVersion := "2.11.8"
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-encoding", "UTF-8")
 scalacOptions += "-deprecation"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"         %% "play"               % "2.4.0"     % "provided",
-  "com.typesafe.play"         %% "play-cache"         % "2.4.0",
+  "com.typesafe.play"         %% "play"               % "2.5.0"     % "provided",
+  "com.typesafe.play"         %% "play-cache"         % "2.5.0",
   "biz.source_code"           %  "base64coder"        % "2010-12-19",
   "org.sedis"                 %% "sedis"              % "1.2.2",
-  "com.typesafe.play"         %% "play-test"          % "2.4.0"     % "test",
-  "com.typesafe.play"         %% "play-specs2"        % "2.4.0"     % "test",
+  "com.typesafe.play"         %% "play-test"          % "2.5.0"     % "test",
+  "com.typesafe.play"         %% "play-specs2"        % "2.5.0"     % "test",
   "org.specs2"                %% "specs2-core"        % "3.3.1"     % "test"
 )
 

--- a/redis/build.sbt
+++ b/redis/build.sbt
@@ -6,8 +6,8 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8", "-Xlint:unchecked", "-e
 scalacOptions += "-deprecation"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.play"         %% "play"               % "2.5.0"     % "provided",
-  "com.typesafe.play"         %% "play-cache"         % "2.5.0",
+  "com.typesafe.play"         %% "play"               % "2.5.3"     % "provided",
+  "com.typesafe.play"         %% "play-cache"         % "2.5.3",
   "biz.source_code"           %  "base64coder"        % "2010-12-19",
   "org.sedis"                 %% "sedis"              % "1.2.2",
   "com.typesafe.play"         %% "play-test"          % "2.5.0"     % "test",
@@ -56,4 +56,3 @@ releaseProcess := Seq[ReleaseStep](
   commitNextVersion,
   pushChanges
 )
-

--- a/redis/version.sbt
+++ b/redis/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.4.2-SNAPSHOT"
+version in ThisBuild := "2.5.0-SNAPSHOT"

--- a/run-tests-travis.sh
+++ b/run-tests-travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-if [$PROJECT="redis"]
+if [ "$PROJECT" = "redis" ]
 then
   cd util && sbt +publish-local && cd ../$PROJECT && sbt test
 else

--- a/run-tests-travis.sh
+++ b/run-tests-travis.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -ev
+if [$PROJECT=redis]
+  cd util && sbt +publish-local && cd ../$PROJECT && sbt test
+else
+  cd util && sbt +publish-local && cd ../$PROJECT && sbt +test

--- a/run-tests-travis.sh
+++ b/run-tests-travis.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-if [$PROJECT=redis]
+if [$PROJECT="redis"]
 then
   cd util && sbt +publish-local && cd ../$PROJECT && sbt test
 else

--- a/run-tests-travis.sh
+++ b/run-tests-travis.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ev
 if [$PROJECT=redis]
+then
   cd util && sbt +publish-local && cd ../$PROJECT && sbt test
 else
   cd util && sbt +publish-local && cd ../$PROJECT && sbt +test
+fi


### PR DESCRIPTION
- Updated dependencies for Play 2.5.x
- Updated tests due to deprecated changes in Play 2.5.x
- Updated readme for 2.5 as well as updated the version available for 2.4 in install guide
