### PR TITLE
Redis server offline should not throw exceptions up through the Cache API trait.

### DIFF
--- a/redis/README.md
+++ b/redis/README.md
@@ -136,7 +136,7 @@ and you'll probably need to add this resolver too to resolve Sedis (see [issue](
  ```
 
 play = 2.5.x:
-```"com.typesafe.play.modules" %% "play-modules-redis" % "2.5.0"``` to your dependencies
+```"com.typesafe.play.modules" %% "play-modules-redis" % "2.5.1"``` to your dependencies
 and you'll probably need to add this resolver too to resolve Sedis (see [issue](https://github.com/typesafehub/play-plugins/issues/141)):
 ```resolvers += "google-sedis-fix" at "http://pk11-scratch.googlecode.com/svn/trunk"```
 * The default cache module (EhCache) will be used for all non-named cache UNLESS this module (RedisModule) is the only cache module that was loaded. If this module is the only cache module being loaded, it will work as expected on named and non-named cache. To disable the default cache module so that this Redis Module can be the default cache you must put this in your configuration:

--- a/redis/src/main/scala/com/typesafe/play/redis/RedisCacheApi.scala
+++ b/redis/src/main/scala/com/typesafe/play/redis/RedisCacheApi.scala
@@ -98,6 +98,8 @@ class RedisCacheApi @Inject()(val namespace: String, sedisPool: Pool, classLoade
     } catch {
       case ex: IOException =>
         Logger.warn("could not serialize key:" + key + " and value:" + value.toString + " ex:" + ex.toString)
+      case ex: Exception =>
+        Logger.warn("Unhandled exception trying to set a value in redis for the following key: " + key, ex)
     } finally {
       if (oos != null) oos.close()
       if (dos != null) dos.close()


### PR DESCRIPTION
The get method correctly handled any exceptions raised by Jedis by returning a None, but then your code would probably fetch the real value from the original source (or use getOrElse) and then try to set it into cache for the next request. The set method did not catch exceptions other than IOExceptions which was not enough to catch issues with Jedis not being able to connect to Redis.

The end result was if Redis was down, this plugin would result in the CacheAPI throwing up unexpected exceptions into your application code. This should resolve this issue.
